### PR TITLE
Fix multiple origins in cors header

### DIFF
--- a/project/supabase/functions/README.md
+++ b/project/supabase/functions/README.md
@@ -1,0 +1,53 @@
+# Supabase Edge Functions 環境変数設定ガイド
+
+## ローカル開発環境
+
+ローカルでエッジ関数を開発・テストする場合は、`/supabase/.env.local`ファイルを使用します。
+
+### 設定方法
+
+1. `/supabase/.env.local`ファイルに環境変数を定義
+2. `supabase functions serve`コマンドを実行する際、自動的に読み込まれます
+
+```bash
+# ローカルでエッジ関数を起動
+supabase functions serve --env-file ./supabase/.env.local
+```
+
+## 本番環境（Supabaseダッシュボード）
+
+本番環境では、Supabaseダッシュボードから環境変数を設定します。
+
+### 設定手順
+
+1. [Supabaseダッシュボード](https://app.supabase.com)にログイン
+2. プロジェクトを選択
+3. 左側メニューから「Edge Functions」を選択
+4. 「Settings」タブをクリック
+5. 「Environment Variables」セクションで環境変数を追加
+
+### 必要な環境変数
+
+| 変数名 | 説明 | 例 |
+|--------|------|-----|
+| `ALLOWED_ORIGINS` | 許可されたオリジン（カンマ区切り） | `https://example.com,https://app.example.com` |
+
+### 注意事項
+
+- `SUPABASE_URL`と`SUPABASE_SERVICE_ROLE_KEY`は自動的に設定されるため、手動で設定する必要はありません
+- 環境変数を変更した後は、エッジ関数を再デプロイする必要があります
+
+## デプロイコマンド
+
+```bash
+# 単一の関数をデプロイ
+supabase functions deploy register-user
+
+# すべての関数をデプロイ
+supabase functions deploy
+```
+
+## CORS設定について
+
+現在のエッジ関数は、リクエストのオリジンに基づいて動的にCORSヘッダーを設定します。
+`ALLOWED_ORIGINS`環境変数にカンマ区切りで複数のオリジンを指定できます。


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Dynamically set `Access-Control-Allow-Origin` header in edge functions to fix CORS errors.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The previous implementation set `Access-Control-Allow-Origin` to a comma-separated string of all allowed origins, which is not permitted by the CORS specification. This change introduces a dynamic header generation that checks the request's `Origin` against a list of allowed origins and returns only the matching origin (or `*`) to resolve the "multiple values" error.

---
<a href="https://cursor.com/background-agent?bcId=bc-e2a0fdd9-42d1-4d05-bedb-46643088cd08">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e2a0fdd9-42d1-4d05-bedb-46643088cd08">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>